### PR TITLE
chore: use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))

### DIFF
--- a/db.go
+++ b/db.go
@@ -141,7 +141,7 @@ func (db *MiniDB) Get(key []byte) (val []byte, err error) {
 	offset, ok := db.indexes[string(key)]
 	// key 不存在
 	if !ok {
-		err = errors.New(fmt.Sprintf("{key: %s doesn't exit.}", key))
+		err = fmt.Errorf("{key: %s doesn't exist.}", key)
 		return
 	}
 


### PR DESCRIPTION
1. use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...))
2. typo: exit -> exist