### PR TITLE
fix some merge bugs

### DIFF
--- a/db.go
+++ b/db.go
@@ -78,6 +78,9 @@ func (db *MiniDB) Merge() error {
 		}
 		defer os.Remove(mergeDBFile.File.Name())
 
+		db.mu.Lock()
+		defer db.mu.Unlock()
+
 		// 重新写入有效的 entry
 		for _, entry := range validEntries {
 			writeOff := mergeDBFile.Offset

--- a/db.go
+++ b/db.go
@@ -99,8 +99,6 @@ func (db *MiniDB) Merge() error {
 
 		// 获取文件名
 		mergeDBFileName := mergeDBFile.File.Name()
-		// 关闭文件
-		mergeDBFile.File.Close()
 		// 临时文件变更为新的数据文件
 		os.Rename(mergeDBFileName, filepath.Join(db.dirPath, FileName))
 


### PR DESCRIPTION
1. fix(merge): fix close file after merge, shoule use `db.Close()` to close `db` by user himself.
2. fix(merge):  lock `db` when db file and indexs are swapping.